### PR TITLE
更新で写真が消える不具合

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -254,12 +254,15 @@ def edit_record(record_id):
         return redirect('/')
     record = FishRecord.query.get_or_404(str(record_id))
 
+    photo_status = request.form['photo_status']
     new_photo = request.files['photo']
     if new_photo:
         filename = secure_filename(new_photo.filename)
         new_photo_path = filename
         new_photo.save(upload_folder + '/' + new_photo_path)
         record.photo_path = new_photo_path
+    elif photo_status == 'cleared':
+        record.photo_path = default_photo_path
     else:
         record.photo_path = request.form['existing_photo_path']
         

--- a/app/main.py
+++ b/app/main.py
@@ -261,7 +261,7 @@ def edit_record(record_id):
         new_photo.save(upload_folder + '/' + new_photo_path)
         record.photo_path = new_photo_path
     else:
-        record.photo_path = default_photo_path
+        record.photo_path = request.form['existing_photo_path']
         
     record.fish_name = request.form['fish_name'] or '無銘の魚'
     record.length = request.form['length'] or 999999

--- a/app/templates/edit_record.html
+++ b/app/templates/edit_record.html
@@ -28,6 +28,7 @@
         </div>
 
         <form action="{{ url_for('edit_record', record_id=record.record_id) }}" method="POST" class="modern-form" style="margin-top: 0;" enctype="multipart/form-data" onsubmit="return validateForm()">
+            <input type="hidden" name="existing_photo_path" value="{{ record.photo_path }}">
             <label for="photo">画像（画像か名称は必須です）</label>
             <img id="photo-preview" class="photo-preview"
             {% if record.photo_path != 'default.jpg' %}

--- a/app/templates/edit_record.html
+++ b/app/templates/edit_record.html
@@ -28,6 +28,7 @@
         </div>
 
         <form action="{{ url_for('edit_record', record_id=record.record_id) }}" method="POST" class="modern-form" style="margin-top: 0;" enctype="multipart/form-data" onsubmit="return validateForm()">
+            <input type="hidden" id="photo_status" name="photo_status" value="unchanged">
             <input type="hidden" name="existing_photo_path" value="{{ record.photo_path }}">
             <label for="photo">画像（画像か名称は必須です）</label>
             <img id="photo-preview" class="photo-preview"
@@ -38,8 +39,8 @@
             {% endif %}
             alt="写真プレビュー">
             <div style="display: flex;" class = form-button-container>
-                <input type="file" id="photo" name="photo" class="form" onchange="previewImage(event)">
-                <button type="button" class="button" onclick="clearPreviewImage()"><i class="fa-solid fa-trash"></i></button>
+                <input type="file" id="photo" name="photo" class="form" onchange="previewImage(event); setPhotoStatus('changed');">
+                <button type="button" class="button" onclick="clearPreviewImage(); setPhotoStatus('cleared');"><i class="fa-solid fa-trash"></i></button>
             </div>
 
             <label for="fish_name">名称（画像か名称は必須です）</label>
@@ -89,5 +90,10 @@
     
     <script src="{{ url_for('static', filename='js/preview.js') }}"></script>        
     <script src="{{ url_for('static', filename='js/validate-form.js') }}"></script>
+    <script>
+        function setPhotoStatus(status) {
+            document.getElementById('photo_status').value = status;
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
写真アップロードフォームがクリックされたとき、写真は「更新」された状態になる。
写真削除ボタンがクリックされたとき、写真は「削除」された状態になる。

その情報を保持し、
「更新」されているときにアップロードされたデータがないなら元の写真を保持し、
「削除」されているときは写真をデフォルトにする。